### PR TITLE
Update binary provider and package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # openjdk11
 
-OpenJDK is a free and open-source implementation of the Java Platform, Standard Edition. It is the result of an effort Sun Microsystems began in 2006. The implementation is licensed under the GNU General Public License version 2 with a linking exception.  See [documentation](https://openjdk.java.net)
+OpenJDK is a free and open-source implementation of the Java Platform, Standard Edition. It is the result of an effort Sun Microsystems began in 2006. The implementation is licensed under the GNU General Public License version 2 with a linking exception. See [documentation](https://openjdk.java.net).
+
+Eclipse Adoptium (AdoptOpenJDK) is the binary provider to allow for continued minor version and patch updates since Oracle's public update period for OpenJDK 11 ended after March 2019 (6 months after the initial September 2018 release per Oracle's standard OpenJDK public updates period). See ['Java is Still Free'](https://docs.google.com/document/d/1nFGazvrCvHMZJgFstlbzoHjpAVwv5DEdnaBr_5pKuHo/preview#), "Backing Adoptium (previously AdoptOpenJDK) is Alibaba, Amazon, Azul, Huawei, IBM, Microsoft, Pivotal, Red Hat, and many others."
 
 ## Maintainers
 
@@ -14,7 +16,7 @@ Binary package
 
 ### Use as Dependency
 
-Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://docs.chef.io/habitat/plan_writing/#define-your-dependencies) for more information.
 
 To add core/openjdk11 as a dependency, you can add one of the following to your plan file.
 
@@ -48,6 +50,7 @@ will add the following binaries to the PATH:
 * /bin/jdb
 * /bin/jdeprscan
 * /bin/jdeps
+* /bin/jfr
 * /bin/jhsdb
 * /bin/jimage
 * /bin/jinfo
@@ -69,90 +72,15 @@ will add the following binaries to the PATH:
 * /bin/serialver
 * /bin/unpack200
 
-For example:
-
-```bash
-$ hab pkg install core/openjdk11 --binlink
-Installing core/openjdk11
-☁ Determining latest version of core/openjdk11 in the 'stable' channel
-→ Found newer installed version (core/openjdk11/11.0.2/20200929091217) than remote version (core/openjdk11/11.0.2/20200404235521)
-→ Using core/openjdk11/11.0.2/20200929091217
-★ Install of core/openjdk11/11.0.2/20200929091217 complete with 0 new packages installed.
-» Binlinking javadoc from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked javadoc from core/openjdk11/11.0.2/20200929091217 to /bin/javadoc
-» Binlinking keytool from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked keytool from core/openjdk11/11.0.2/20200929091217 to /bin/keytool
-» Binlinking javac from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked javac from core/openjdk11/11.0.2/20200929091217 to /bin/javac
-» Binlinking jdeps from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jdeps from core/openjdk11/11.0.2/20200929091217 to /bin/jdeps
-» Binlinking jcmd from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jcmd from core/openjdk11/11.0.2/20200929091217 to /bin/jcmd
-» Binlinking jjs from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jjs from core/openjdk11/11.0.2/20200929091217 to /bin/jjs
-» Binlinking jmod from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jmod from core/openjdk11/11.0.2/20200929091217 to /bin/jmod
-» Binlinking jconsole from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jconsole from core/openjdk11/11.0.2/20200929091217 to /bin/jconsole
-» Binlinking jimage from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jimage from core/openjdk11/11.0.2/20200929091217 to /bin/jimage
-» Binlinking jps from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jps from core/openjdk11/11.0.2/20200929091217 to /bin/jps
-» Binlinking rmic from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked rmic from core/openjdk11/11.0.2/20200929091217 to /bin/rmic
-» Binlinking jar from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jar from core/openjdk11/11.0.2/20200929091217 to /bin/jar
-» Binlinking jlink from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jlink from core/openjdk11/11.0.2/20200929091217 to /bin/jlink
-» Binlinking jstat from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jstat from core/openjdk11/11.0.2/20200929091217 to /bin/jstat
-» Binlinking jinfo from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jinfo from core/openjdk11/11.0.2/20200929091217 to /bin/jinfo
-» Binlinking jstack from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jstack from core/openjdk11/11.0.2/20200929091217 to /bin/jstack
-» Binlinking jshell from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jshell from core/openjdk11/11.0.2/20200929091217 to /bin/jshell
-» Binlinking unpack200 from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked unpack200 from core/openjdk11/11.0.2/20200929091217 to /bin/unpack200
-» Binlinking jdb from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jdb from core/openjdk11/11.0.2/20200929091217 to /bin/jdb
-» Binlinking jdeprscan from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jdeprscan from core/openjdk11/11.0.2/20200929091217 to /bin/jdeprscan
-» Binlinking java from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked java from core/openjdk11/11.0.2/20200929091217 to /bin/java
-» Binlinking rmiregistry from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked rmiregistry from core/openjdk11/11.0.2/20200929091217 to /bin/rmiregistry
-» Binlinking jarsigner from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jarsigner from core/openjdk11/11.0.2/20200929091217 to /bin/jarsigner
-» Binlinking jaotc from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jaotc from core/openjdk11/11.0.2/20200929091217 to /bin/jaotc
-» Binlinking rmid from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked rmid from core/openjdk11/11.0.2/20200929091217 to /bin/rmid
-» Binlinking jstatd from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jstatd from core/openjdk11/11.0.2/20200929091217 to /bin/jstatd
-» Binlinking serialver from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked serialver from core/openjdk11/11.0.2/20200929091217 to /bin/serialver
-» Binlinking pack200 from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked pack200 from core/openjdk11/11.0.2/20200929091217 to /bin/pack200
-» Binlinking javap from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked javap from core/openjdk11/11.0.2/20200929091217 to /bin/javap
-» Binlinking jrunscript from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jrunscript from core/openjdk11/11.0.2/20200929091217 to /bin/jrunscript
-» Binlinking jhsdb from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jhsdb from core/openjdk11/11.0.2/20200929091217 to /bin/jhsdb
-» Binlinking jmap from core/openjdk11/11.0.2/20200929091217 into /bin
-★ Binlinked jmap from core/openjdk11/11.0.2/20200929091217 to /bin/jmap
-```
-
 #### Using an example binary
 
-You can now use the binary as normal.  For example:
+You can now use the binary as normal. For example:
 
 ``/bin/java --version`` or ``java --version``
 
 ```bash
 $ java --version
-openjdk 11.0.2 2019-01-15
-OpenJDK Runtime Environment 18.9 (build 11.0.2+9)
-OpenJDK 64-Bit Server VM 18.9 (build 11.0.2+9, mixed mode)
+openjdk 11.0.11 2021-04-20
+OpenJDK Runtime Environment AdoptOpenJDK-11.0.11+9 (build 11.0.11+9)
+OpenJDK 64-Bit Server VM AdoptOpenJDK-11.0.11+9 (build 11.0.11+9, mixed mode)
 ```

--- a/controls/openjdk11_exists.rb
+++ b/controls/openjdk11_exists.rb
@@ -30,6 +30,7 @@ control 'core-plans-openjdk11-exists' do
   "jdb",
   "jdeprscan",
   "jdeps",
+  "jfr",
   "jhsdb",
   "jimage",
   "jinfo",

--- a/controls/openjdk11_works.rb
+++ b/controls/openjdk11_works.rb
@@ -44,6 +44,10 @@ control 'core-plans-openjdk11-works' do
       exit_pattern: /^[^0]{1}\d*$/,
     },
     "jdeps" => {},
+    "jfr" => {
+      command_suffix: "--help",
+      command_output_pattern: /Tool for working with Flight Recorder files/,
+    },
     "jhsdb" => {
       command_suffix: "--help",
       command_output_pattern: /clhsdb\s+command line debugger/,

--- a/inspec.yml
+++ b/inspec.yml
@@ -2,6 +2,6 @@ name: openjdk11
 title: Habitat Core Plan openjdk11
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
 summary: InSpec controls for testing Habitat Core Plan openjdk11
-version: 0.1.0
+version: 0.2.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,15 +1,16 @@
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_name=openjdk11
-# NOTE: Retrieve download link and shasum from here: https://jdk.java.net/11/
-pkg_version=11.0.2
-pkg_source=https://download.java.net/java/GA/jdk11/9/GPL/openjdk-${pkg_version}_linux-x64_bin.tar.gz
-pkg_shasum=99be79935354f5c0df1ad293620ea36d13f48ec3ea870c838f20c504c9668b57
-pkg_filename=openjdk-${pkg_version}_linux-x64_bin.tar.gz
-pkg_dirname="jdk-${pkg_version}"
-pkg_license=("GPL-2.0-only")
-pkg_description=('OpenJDK is a free and open-source implementation of the Java Platform, Standard Edition.')
-pkg_upstream_url=https://openjdk.java.net/
+# NOTE: Retrieve download link and shasum from here: https://adoptopenjdk.net/releases.html
+pkg_version=11.0.11
+pkg_patch_lvl=9
+pkg_source="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-${pkg_version}%2B${pkg_patch_lvl}/OpenJDK11U-jdk_x64_linux_hotspot_${pkg_version}_${pkg_patch_lvl}.tar.gz"
+pkg_shasum=e99b98f851541202ab64401594901e583b764e368814320eba442095251e78cb
+pkg_filename="OpenJDK11U-jdk_x64_linux_hotspot_${pkg_version}_${pkg_patch_lvl}.tar.gz"
+pkg_dirname="jdk-${pkg_version}+${pkg_patch_lvl}"
+pkg_license=("GPL-2.0-only WITH Classpath-exception-2.0")
+pkg_description=('OpenJDK is a free and open-source implementation of the Java Platform, Standard Edition. AdoptOpenJDK provides binaries from the upstream OpenJDK source code.')
+pkg_upstream_url=https://adoptopenjdk.net/about.html
 pkg_deps=(
   core/alsa-lib
   core/freetype
@@ -47,7 +48,7 @@ do_install() {
   build_line "Setting rpath for all libraries to '$LD_RUN_PATH'"
 
   find "$pkg_prefix"/bin -type f -executable \
-    -exec sh -c 'file -i "$1" | grep -q "x-executable; charset=binary"' _ {} \; \
+    -exec sh -c 'file -i "$1" | grep -q "x-pie-executable; charset=binary"' _ {} \; \
     -exec patchelf --interpreter "$(pkg_path_for glibc)/lib/ld-linux-x86-64.so.2" --set-rpath "${LD_RUN_PATH}" {} \;
 
   find "$pkg_prefix/lib" -type f -name "*.so" \


### PR DESCRIPTION
This proposed change moves to Eclipse Adoptium (AdoptOpenJDK) as the binary provider for OpenJDK 11 to allow for continued minor version and patch updates since Oracle's public update period for OpenJDK 11 ended after March 2019 (6 months after the initial September 2018 release per Oracle's standard OpenJDK public updates period). See ['Java is Still Free'](https://docs.google.com/document/d/1nFGazvrCvHMZJgFstlbzoHjpAVwv5DEdnaBr_5pKuHo/preview#), "Backing Adoptium (previously AdoptOpenJDK) is Alibaba, Amazon, Azul, Huawei, IBM, Microsoft, Pivotal, Red Hat, and many others." The chef/automate-openjdk package uses Adoptium's openjdk11 binary. See also for context, the [Eclipse Adoptium Charter](https://projects.eclipse.org/projects/adoptium/charter).

This change also updates the version from 11.0.2 to the latest available, 11.0.11+9.

#### Test notes
Built package locally against my own origin (nateoconnell).
```
$ hab studio enter
   hab-studio: Importing 'nateoconnell' secret origin key
» Importing origin key from standard input
★ Imported secret origin key nateoconnell-20210324191627
   hab-studio: Importing 'nateoconnell' public origin key
» Importing origin key from standard input
★ Imported public origin key nateoconnell-20210324191627
   hab-studio: Exported: HAB_AUTH_TOKEN=[redacted]
   hab-studio: Exported: HAB_LICENSE=accept-no-persist
   hab-studio: Exported: HAB_ORIGIN=nateoconnell
   hab-studio: Exported: HAB_BLDR_URL=https://bldr.habitat.sh
[...]

[1][default:/src:0]# build
   : Loading /src/plan.sh
   openjdk11: Plan loaded
   openjdk11: Validating plan metadata
   openjdk11: Using HAB_BIN=/hab/pkgs/core/hab/1.6.319/20210512011554/bin/hab for installs, signing, and hashing
   openjdk11: hab-plan-build setup
   openjdk11: Writing pre_build file
   openjdk11: Resolving build dependencies
[...]
   openjdk11: Source Path: /hab/cache/src/jdk-11.0.11+9
   openjdk11: Installed Path: /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414
   openjdk11: Artifact: /src/results/nateoconnell-openjdk11-11.0.11-20210628145414-x86_64-linux.hart
   openjdk11: Build Report: /src/results/last_build.env
   openjdk11: SHA256 Checksum: 556fb80cdd31eaa34c468b483aff266b8ceeeed15fc126883697140838932c47
   openjdk11: Blake2b Checksum: 99ab82b543a085465178492d35f9b157ad54e7818597b72588c3fc9ad32fb5be
   openjdk11:
   openjdk11: I love it when a plan.sh comes together.
   openjdk11:
   openjdk11: Build time: 2m38s
```
Installed the package in a chef/chefworkstation container.
```
$ docker run --rm -it -v $(pwd):/build -w /build -v ~/.hab/cache/keys:/hab/cache/keys -e HAB_ORIGIN=nateoconnell -e HAB_LICENSE=accept-no-persist -e CHEF_LICENSE=accept-no-persist chef/chefworkstation bash

root@7caaaf452a94:/build# source results/last_build.env
root@7caaaf452a94:/build# hab pkg install results/${pkg_artifact}
» Installing results/nateoconnell-openjdk11-11.0.11-20210628145414-x86_64-linux.hart
☛ Verifying nateoconnell/openjdk11/11.0.11/20210628145414
↓ Downloading core/alsa-lib/1.1.9/20200404040530 for x86_64-linux
    395.58 KB / 395.58 KB / [===================================================================================] 100.00 % 121.61 MB/s
☛ Verifying core/alsa-lib/1.1.9/20200404040530
[...]
★ Install of nateoconnell/openjdk11/11.0.11/20210628145414 complete with 27 new packages installed.
```
Verified that the inspec tests pass.
```
root@7caaaf452a94:/build# inspec exec .

Profile: Habitat Core Plan openjdk11 (openjdk11)
Version: 0.1.0
Target:  local://

  ✔  core-plans-openjdk11-exists: Ensure openjdk11 exists
     ✔  Command: `hab pkg path nateoconnell/openjdk11` exit_status is expected to eq 0
     ✔  Command: `hab pkg path nateoconnell/openjdk11` stdout is expected not to be empty
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jaotc is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jaotc is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jar is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jar is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jarsigner is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jarsigner is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/java is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/java is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javac is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javac is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javadoc is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javadoc is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javap is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javap is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jcmd is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jcmd is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jconsole is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jconsole is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdb is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdb is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeprscan is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeprscan is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeps is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeps is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jhsdb is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jhsdb is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jimage is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jimage is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jinfo is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jinfo is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jjs is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jjs is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jlink is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jlink is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmap is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmap is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmod is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmod is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jps is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jps is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jrunscript is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jrunscript is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jshell is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jshell is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstack is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstack is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstat is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstat is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstatd is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstatd is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/keytool is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/keytool is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/pack200 is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/pack200 is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmic is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmic is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmid is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmid is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmiregistry is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmiregistry is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/serialver is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/serialver is expected to be executable
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/unpack200 is expected to exist
     ✔  File /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/unpack200 is expected to be executable
  ✔  core-plans-openjdk11-works: Ensure openjdk11 works as expected
     ✔  Command: `hab pkg path nateoconnell/openjdk11` exit_status is expected to eq 0
     ✔  Command: `hab pkg path nateoconnell/openjdk11` stdout is expected not to be empty
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jaotc  2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jaotc  2>&1 stdout is expected to match /usage:(\s+|.*)jaotc/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jar  2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jar  2>&1 stdout is expected to match /usage:(\s+|.*)jar/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jarsigner -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jarsigner -help 2>&1 stdout is expected to match /usage:(\s+|.*)jarsigner/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/java -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/java -help 2>&1 stdout is expected to match /usage:(\s+|.*)java/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javac -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javac -help 2>&1 stdout is expected to match /usage:(\s+|.*)javac/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javadoc -- 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javadoc -- 2>&1 stdout is expected to match /usage:(\s+|.*)javadoc/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javap -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/javap -help 2>&1 stdout is expected to match /usage:(\s+|.*)javap/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jcmd -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jcmd -help 2>&1 stdout is expected to match /usage:(\s+|.*)jcmd/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdb -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdb -help 2>&1 stdout is expected to match /usage:(\s+|.*)jdb/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeprscan -help 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeprscan -help 2>&1 stdout is expected to match /usage:(\s+|.*)jdeprscan/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeps -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jdeps -help 2>&1 stdout is expected to match /usage:(\s+|.*)jdeps/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jhsdb --help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jhsdb --help 2>&1 stdout is expected to match /clhsdb\s+command line debugger/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jimage -help 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jimage -help 2>&1 stdout is expected to match /usage:(\s+|.*)jimage/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jinfo  2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jinfo  2>&1 stdout is expected to match /jinfo <option> <pid>/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jjs -help 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jjs -help 2>&1 stdout is expected to match /jjs \[<options>\] <files> \[-- <arguments>\]/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jlink -help 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jlink -help 2>&1 stdout is expected to match /usage:(\s+|.*)jlink/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmap -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmap -help 2>&1 stdout is expected to match /usage:(\s+|.*)jmap/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmod -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jmod -help 2>&1 stdout is expected to match /usage:(\s+|.*)jmod/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jps -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jps -help 2>&1 stdout is expected to match /usage:(\s+|.*)jps/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jrunscript -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jrunscript -help 2>&1 stdout is expected to match /usage:(\s+|.*)jrunscript/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jshell -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jshell -help 2>&1 stdout is expected to match /usage:(\s+|.*)jshell/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstack -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstack -help 2>&1 stdout is expected to match /usage:(\s+|.*)jstack/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstat -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstat -help 2>&1 stdout is expected to match /usage:(\s+|.*)jstat/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstatd -help 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/jstatd -help 2>&1 stdout is expected to match /usage:(\s+|.*)jstatd/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/keytool -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/keytool -help 2>&1 stdout is expected to match /Key and Certificate Management Tool/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/pack200 -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/pack200 -help 2>&1 stdout is expected to match /usage:(\s+|.*)pack200/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmic -help 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmic -help 2>&1 stdout is expected to match /usage:(\s+|.*)rmic/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmid timeout 1 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmid timeout 1 2>&1 stdout is expected to match /usage:(\s+|.*)rmid/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmiregistry timeout 1 2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/rmiregistry timeout 1 2>&1 stdout is expected to match /usage:(\s+|.*)rmiregistry/i
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/serialver  2>&1 exit_status is expected to cmp == /^[^0]{1}\d*$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/serialver  2>&1 stdout is expected to match /use: serialver \[-classpath classpath\]/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/unpack200 -help 2>&1 exit_status is expected to cmp == /^[0]$/
     ✔  Bash command /hab/pkgs/nateoconnell/openjdk11/11.0.11/20210628145414/bin/unpack200 -help 2>&1 stdout is expected to match /usage:(\s+|.*)unpack200/i


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 130 successful, 0 failures, 0 skipped
```